### PR TITLE
Add reading routes configuration from Kubernetes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,12 +79,14 @@ dependencies {
     compile 'com.github.zensum:ktor-health-check:e7365fd'
     compile 'io.ktor:ktor-server-core:0.9.5'
     compile 'io.ktor:ktor-server-netty:0.9.5'
+    compile "io.ktor:ktor-server-test-host:0.9.5"
     testCompile "io.ktor:ktor-server-test-host:0.9.5"
     compile 'com.moandjiezana.toml:toml4j:0.7.2'
     compile 'com.github.jonross:fauxflake:90abbcf5b6'
     implementation "com.github.mantono:pyttipanna:0.2.0"
     implementation 'com.google.code.gson:gson:2.8.5'
     implementation(group: "com.github.everit-org.json-schema", name: "org.everit.json.schema", version: "1.11.0")
+    implementation "com.fasterxml.jackson.module:jackson-module-kotlin:2.9.+"
 }
 
 junitPlatform {

--- a/docker-compose-kafka-cluster.yaml
+++ b/docker-compose-kafka-cluster.yaml
@@ -27,3 +27,5 @@ services:
       - 80:80
     environment:
       KAFKA_HOST: "kafka:9092"
+      KUBERNETES_ENABLE: "false"
+

--- a/src/integrationTest/object1.yaml
+++ b/src/integrationTest/object1.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: leia.klira.io/v1
+kind: LeiaRoute
+metadata:
+  name: route1
+spec:
+  path: "/status/mail"
+  topic: "mail"
+  verify: false
+  format: "proto"
+  methods: [ "POST", "PUT", "HEAD", "GET" ]

--- a/src/integrationTest/object2.yaml
+++ b/src/integrationTest/object2.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: leia.klira.io/v1
+kind: LeiaRoute
+metadata:
+  name: route2
+spec:
+  path: "/jsonTest"
+  topic: "test"
+  verify: false
+  format: "proto"
+  methods: [ "POST" ]
+  validateJson: true
+  jsonSchema: |
+    {
+      "$id": "https://example.com/person.schema.json",
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "title": "Person",
+      "type": "object",
+      "properties": {
+        "firstName": {
+          "type": "string",
+          "description": "The person's first name."
+        },
+        "lastName": {
+          "type": "string",
+          "description": "The person's last name."
+        },
+        "age": {
+          "description": "Age in years which must be equal to or greater than zero.",
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    }

--- a/src/integrationTest/resourcedefinition.yaml
+++ b/src/integrationTest/resourcedefinition.yaml
@@ -1,0 +1,17 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: leiaroutes.leia.klira.io
+spec:
+  group: leia.klira.io
+  versions:
+    - name: v1
+      served: true
+      storage: true
+  scope: Namespaced
+  names:
+    plural: leiaroutes
+    singular: leiaroute
+    kind: LeiaRoute
+    shortNames:
+    - lr

--- a/src/main/kotlin/registry/K8sRegistry.kt
+++ b/src/main/kotlin/registry/K8sRegistry.kt
@@ -1,0 +1,142 @@
+package leia.registry
+
+import com.fasterxml.jackson.core.JsonFactory
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.KotlinModule
+import com.fasterxml.jackson.module.kotlin.MissingKotlinParameterException
+import io.ktor.client.HttpClient
+import io.ktor.client.call.call
+import io.ktor.client.request.HttpRequestBuilder
+import io.ktor.client.response.readBytes
+import io.ktor.http.HttpMethod
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.experimental.runBlocking
+import mu.KLogging
+import java.net.ConnectException
+import java.nio.channels.UnresolvedAddressException
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+
+class K8sResourceHolder(private val parser: (String) -> List<K8sRegistry.RouteItem>) {
+    private val entriesA = AtomicReference(listOf<K8sRegistry.RouteItem>())
+    fun onChange(yaml: String) {
+        entriesA.updateAndGet {
+            try {
+                parser(yaml)
+            } catch (e: MissingKotlinParameterException) {
+                K8sRegistry.logger.error { K8sRegistry.logger.error { "Failed to read objects from kubernetes: ${e.message}" } }
+                it
+            }
+        }
+    }
+
+    fun getData(): List<K8sRegistry.RouteItem> = entriesA.get()
+}
+
+// Auto-watching registry for a directory of Kubernetes Yaml files.
+class K8sRegistry(private val host: String, private val port: String) : Registry {
+    private val watchers = mutableListOf<Triple<String, (Map<String, Any>) -> Any, (List<*>) -> Unit>>()
+    private val holder = K8sResourceHolder { yaml ->
+        val mapper = ObjectMapper(JsonFactory())
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+        mapper.registerModule(KotlinModule()) // Enable Kotlin support
+        val routes = mapper.readValue(yaml, K8sRegistry.Routes::class.java)
+        routes.items.filter { apiVersions.contains(it.apiVersion) }
+    }
+
+    private val scheduler = Executors.newScheduledThreadPool(1)
+
+    init {
+        scheduler.scheduleAtFixedRate({ this.forceUpdate() }, 1, 1, TimeUnit.MINUTES)
+    }
+
+    override fun getMaps(name: String): List<Map<String, Any>> =
+        holder.getData().filter { it.kind == nameToKind[name] }.map { it.spec.toMap() }
+
+    private fun onUpdate(yaml: String) {
+        holder.onChange(yaml)
+        watchers.forEach { (table, fn, handler) -> handler(getMaps(table).map { fn(it) }) }
+        logger.info { "Loaded ${holder.getData().size} objects from kubernetes" }
+    }
+
+    private fun getPort(): Int  = try {
+        port.toInt()
+    } catch (e: NumberFormatException) {
+        logger.error { "Invalid port number: $port, using default 8080" }
+        DEFAULT_KUBERNETES_PORT.toInt()
+    }
+
+    override fun forceUpdate() {
+        logger.info("Polling all objects from kubernetes")
+        val builder = HttpRequestBuilder()
+            .also { it.method = HttpMethod.Get }
+            .also { it.url.also { url ->
+                url.host = host
+                url.port = getPort()
+            }.encodedPath = "/apis/leia.klira.io/v1/namespaces/default/leiaroutes" }
+        var error: String? = null
+        try {
+            val response = runBlocking { HttpClient().call(builder).response }
+            val content = runBlocking { response.readBytes().toString(Charsets.UTF_8) }
+
+            onUpdate(content)
+        } catch (e: UnresolvedAddressException) {
+            error = e.message
+        } catch (e: ConnectException) {
+            error = e.message
+        }
+        error?.let { logger.warn { "Failed to connect to kubernetes: $error" }}
+    }
+
+    override fun <T> watch(name: String, fn: (Map<String, Any>) -> T, handler: (List<T>) -> Unit) {
+        val t = Triple<String, (Map<String, Any>) -> Any, (List<*>) -> Unit>(
+            name,
+            fn as ((Map<String, Any>)) -> Any,
+            handler as ((List<*>) -> Unit)
+        )
+        watchers.add(t)
+    }
+
+    companion object : KLogging() {
+        const val DEFAULT_KUBERNETES_HOST = "localhost"
+        const val DEFAULT_KUBERNETES_PORT = "8080"
+        const val DEFAULT_KUBERNETES_ENABLE = "true"
+        val nameToKind = hashMapOf("routes" to "LeiaRoute")
+        val apiVersions = listOf("leia.klira.io/v1") // supported versions
+    }
+
+    // classes representing Custom Resource Definition in Kubernetes
+    data class Routes(val apiVersion: String, val items: List<RouteItem>)
+
+    data class RouteItem(val apiVersion: String, val kind: String, val spec: Route)
+    data class Route(val path: String,
+                     val topic: String,
+                     val format: String? = null,
+                     val verify: Boolean? = null,
+                     val methods: Collection<String>? = null,
+                     val cors: List<String>? = null,
+                     val response: HttpStatusCode? = null,
+                     val sink: String? = null,
+                     val authenticateUsing: List<String>? = null,
+                     val validateJson: Boolean?,
+                     val jsonSchema: String? = null) {
+        fun toMap(): Map<String, Any> {
+            val map = HashMap<String, Any>()
+            map["path"] = path
+            map["topic"] = topic
+            format?.let { map["format"] = it }
+            verify?.let { map["verify"] = it }
+            methods?.let { map["methods"] = it }
+            cors?.let { map["cors"] = it }
+            response?.let { map["response"] = it }
+            sink?.let { map["sink"] = it }
+            authenticateUsing?.let { map["authenticateUsing"] = it }
+            validateJson?.let { map["validateJson"] = it }
+            jsonSchema?.let { map["jsonSchema"] = it }
+            return map
+        }
+    }
+}
+

--- a/src/main/kotlin/registry/K8sRegistry.kt
+++ b/src/main/kotlin/registry/K8sRegistry.kt
@@ -38,10 +38,10 @@ class K8sResourceHolder(private val parser: (String) -> List<K8sRegistry.RouteIt
 // Auto-watching registry for a directory of Kubernetes Yaml files.
 class K8sRegistry(private val host: String, private val port: String) : Registry {
     private val watchers = mutableListOf<Triple<String, (Map<String, Any>) -> Any, (List<*>) -> Unit>>()
+    private val mapper = ObjectMapper(JsonFactory())
+        .also { it.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false) }
+        .also { it.registerModule(KotlinModule()) }
     private val holder = K8sResourceHolder { yaml ->
-        val mapper = ObjectMapper(JsonFactory())
-        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-        mapper.registerModule(KotlinModule()) // Enable Kotlin support
         val routes = mapper.readValue(yaml, K8sRegistry.Routes::class.java)
         routes.items.filter { apiVersions.contains(it.apiVersion) }
     }

--- a/src/main/kotlin/registry/Registries.kt
+++ b/src/main/kotlin/registry/Registries.kt
@@ -1,0 +1,36 @@
+package leia.registry
+
+import java.util.concurrent.atomic.AtomicReference
+
+class Registries(private val registries: List<Registry>) : Registry {
+
+    private val watchers = mutableListOf<Triple<String, (Map<String, Any>) -> Any, (List<*>) -> Unit>>()
+
+    override fun forceUpdate() {
+        registries.forEach { it.forceUpdate() }
+    }
+
+    override fun getMaps(name: String): List<Map<String, Any>> =
+        registries.map { it.getMaps(name) }.reduce { acc, list -> acc + list }
+
+    private fun onUpdate(name: String) {
+        val maps = getMaps(name)
+        watchers.filter { triple -> triple.first == name }.map { triple ->
+            triple.third(maps.map { triple.second(it) })
+        }
+    }
+
+    override fun <T> watch(name: String, fn: (Map<String, Any>) -> T, handler: (List<T>) -> Unit) {
+        // Generics are insufficient for this, just go with
+        val t = Triple<String, (Map<String, Any>) -> Any, (List<*>) -> Unit>(
+            name,
+            fn as ((Map<String, Any>)) -> Any,
+            handler as ((List<*>) -> Unit)
+        )
+        watchers.add(t)
+        registries.forEach {
+            it.watch(name, {}, { onUpdate(name) })
+        }
+    }
+}
+

--- a/src/main/kotlin/registry/Registry.kt
+++ b/src/main/kotlin/registry/Registry.kt
@@ -5,6 +5,9 @@ package leia.registry
 // opportunity to watch such a collection for changes while providing a transform
 // from JSON-style data to domain types.
 interface Registry {
+    fun forceUpdate()
+    // get list of key value pairs for given type of config e.g. route
+    fun getMaps(name: String): List<Map<String, Any>>
     fun <T> watch(name: String,
                   fn: (Map<String, Any>) -> T,
                   handler: (List<T>) -> Unit)


### PR DESCRIPTION
Reads routes from LeiaRoute custom resource in Kubernetes every minute.
This config source has higher priority than toml files.

This configuration source is enabled by default (disabled in docker compose configuration using env variable KUBERNETES_ENABLE set to false). Kubernetes host and port can be configured using KUBERNETES_SERVICE_HOST and KUBERNETES_SERVICE_PORT variables.

Fixes #62 #72