### PR TITLE
Add redis support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,6 +85,7 @@ dependencies {
     implementation "com.github.mantono:pyttipanna:0.2.0"
     implementation 'com.google.code.gson:gson:2.8.5'
     implementation(group: "com.github.everit-org.json-schema", name: "org.everit.json.schema", version: "1.11.0")
+    implementation group: 'redis.clients', name: 'jedis', version: '3.0.1'
 }
 
 junitPlatform {

--- a/example-config/cfg.toml
+++ b/example-config/cfg.toml
@@ -37,6 +37,7 @@ title = "Routes config"
   }
 }
 """
+
 [[sink-providers]]
     name = "kafka"
     type = "kafka"
@@ -45,5 +46,11 @@ title = "Routes config"
         host = "kafka:9092"
 
 
+#[[sink-providers]]
+#    name = "redis"
+#    type = "redis"
+#    [sink-providers.options]
+#        host = "localhost"
+#        port = "6379"
 
 

--- a/src/main/kotlin/sink/DefaultSinkProviderFactory.kt
+++ b/src/main/kotlin/sink/DefaultSinkProviderFactory.kt
@@ -7,6 +7,7 @@ class DefaultSinkProviderFactory : SinkProviderFactory {
         when(spec.type.toLowerCase()) {
             "null" -> NullSinkProvider
             "kafka" -> KafkaSinkProvider(spec.options["host"] as String?)
+            "redis" -> RedisSinkProvider(spec.options["host"] as String?, (spec.options["port"] as String?) ?.toIntOrNull())
             "always-error" -> AlwaysErrorSinkProvider(spec.options["message"] as String)
             else ->
                 throw RuntimeException("No sinkProvider matching type ${spec.type}")

--- a/src/main/kotlin/sink/RedisSink.kt
+++ b/src/main/kotlin/sink/RedisSink.kt
@@ -1,0 +1,39 @@
+package leia.sink
+
+import leia.logic.IncomingRequest
+import leia.logic.SinkDescription
+import redis.clients.jedis.Jedis
+
+
+private fun mkJedis(host: String? = null, port: Int? = null) = when {
+    host != null && port != null -> Jedis(host, port)
+    host != null -> Jedis(host)
+    else -> Jedis()
+}
+
+private fun <K, V> Map<K, V>.with(addend: Pair<K, V?>?): Map<K, V> =
+    if (addend?.second != null)
+        plus(addend.first to addend.second!!).toMap()
+    else this
+
+private class RedisSink(
+    private val jedis: Jedis,
+    private val description: SinkDescription
+) : Sink {
+    override suspend fun handle(incomingRequest: IncomingRequest): SinkResult {
+        val body = description.dataFormat.generateBody(incomingRequest)
+
+        return try {
+            jedis.publish(description.topic.toByteArray(), body)
+            SinkResult.SuccessfullyWritten
+        } catch (exc: Exception) {
+            SinkResult.WritingFailed(exc)
+        }
+    }
+}
+
+class RedisSinkProvider(private val host: String? = null, port: Int? = null) : SinkProvider {
+    private val jedis = mkJedis(host, port)
+    override fun sinkFor(description: SinkDescription): Sink? =
+        RedisSink(jedis, description)
+}


### PR DESCRIPTION
If redis sink is chosen for a route, http body will be sent to channel specified
by topic config field. Unlike kafka sink key and headers are not sent.