### PR TITLE
Add Redis tests

### DIFF
--- a/docker-compose-redis-kafka-cluster.yaml
+++ b/docker-compose-redis-kafka-cluster.yaml
@@ -21,11 +21,16 @@ services:
     image: redis:5.0.3-alpine
     command: ["redis-server", "--appendonly", "yes"]
     hostname: redis
+    expose:
+      - "6379"
+    ports:
+      - "6379:6379"
 
   leia:
     build: .
     depends_on:
       - kafka
+      - redis
     volumes:
       - ./example-config:/etc/config/
     ports:

--- a/docker-compose-redis-kafka-cluster.yaml
+++ b/docker-compose-redis-kafka-cluster.yaml
@@ -1,0 +1,36 @@
+---
+version: '2'
+services:
+  zookeeper:
+    image: confluentinc/cp-zookeeper:latest
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 32181
+      ZOOKEEPER_TICK_TIME: 2000
+
+  kafka:
+    image: confluentinc/cp-kafka:latest
+    depends_on:
+      - zookeeper
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:32181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+
+  redis:
+    image: redis:5.0.3-alpine
+    command: ["redis-server", "--appendonly", "yes"]
+    hostname: redis
+
+  leia:
+    build: .
+    depends_on:
+      - kafka
+    volumes:
+      - ./example-config:/etc/config/
+    ports:
+      - 80:80
+    environment:
+      KAFKA_HOST: "kafka:9092"
+      KUBERNETES_ENABLE: "false"
+

--- a/example-config/redis.toml
+++ b/example-config/redis.toml
@@ -5,14 +5,14 @@ title = "Redis config"
 	sink = "redis"
 	topic = "test"
 	verify = false
-	format = "proto"
+	format = "raw_body"
 	methods = [ "POST", "GET", "HEAD", "OPTIONS" ]
 
 [[routes]]
 	path = "/redis/with_cors"
 	sink = "redis"
 	topic = "test"
-	format = "proto"
+	format = "raw_body"
 	methods = [ "POST", "GET", "HEAD" ]
     cors = [ "http://example.com" ]
 
@@ -20,8 +20,15 @@ title = "Redis config"
 	path = "/redis/json"
 	sink = "redis"
 	topic = "test"
-	verify = false
-	format = "proto"
+	format = "raw_body"
+	methods = [ "POST" ]
+    validateJson = true
+
+[[routes]]
+	path = "/redis/json_schema"
+	sink = "redis"
+	topic = "test"
+	format = "raw_body"
 	methods = [ "POST" ]
     validateJson = true
     jsonSchema = """

--- a/example-config/redis.toml
+++ b/example-config/redis.toml
@@ -1,21 +1,24 @@
-title = "Sample config"
+title = "Redis config"
 
 [[routes]]
-	path = "/"
+	path = "/redis"
+	sink = "redis"
 	topic = "test"
 	verify = false
 	format = "proto"
 	methods = [ "POST", "GET", "HEAD", "OPTIONS" ]
 
 [[routes]]
-	path = "/with_cors"
+	path = "/redis/with_cors"
+	sink = "redis"
 	topic = "test"
 	format = "proto"
 	methods = [ "POST", "GET", "HEAD" ]
     cors = [ "http://example.com" ]
 
 [[routes]]
-	path = "/json"
+	path = "/redis/json"
+	sink = "redis"
 	topic = "test"
 	verify = false
 	format = "proto"
@@ -46,23 +49,8 @@ title = "Sample config"
 """
 
 [[sink-providers]]
-    name = "kafka"
-    type = "kafka"
-    default = true
+    name = "redis"
+    type = "redis"
     [sink-providers.options]
-        host = "kafka:9092"
-
-
-#[[sink-providers]]
-#    name = "redis"
-#    type = "redis"
-#    [sink-providers.options]
-#        host = "redis"
-#        port = "6379"
-
-#[[sink-providers]]
-#    name = "gpubsub"
-#    type = "gpubsub"
-#    [sink-providers.options]
-#        projectId = "<your-project-id>"
-
+        host = "redis"
+        port = "6379"

--- a/src/integrationTest/java/leia/IntegrationTestBaseRule.java
+++ b/src/integrationTest/java/leia/IntegrationTestBaseRule.java
@@ -17,6 +17,7 @@ public class IntegrationTestBaseRule {
         new DockerComposeContainer(new File("docker-compose-redis-kafka-cluster.yaml"))
             .withExposedService("zookeeper", 32181)
             .withExposedService("kafka", 9092)
+            .withExposedService("redis", 6379)
             .withExposedService("leia", 80)
             .withLocalCompose(true);
 }

--- a/src/integrationTest/java/leia/IntegrationTestBaseRule.java
+++ b/src/integrationTest/java/leia/IntegrationTestBaseRule.java
@@ -14,7 +14,7 @@ public class IntegrationTestBaseRule {
 
     @ClassRule
     public static DockerComposeContainer environment =
-        new DockerComposeContainer(new File("docker-compose-kafka-cluster.yaml"))
+        new DockerComposeContainer(new File("docker-compose-redis-kafka-cluster.yaml"))
             .withExposedService("zookeeper", 32181)
             .withExposedService("kafka", 9092)
             .withExposedService("leia", 80)

--- a/src/integrationTest/kotlin/HttpRequestsTest.kt
+++ b/src/integrationTest/kotlin/HttpRequestsTest.kt
@@ -59,6 +59,14 @@ class HttpRequestsTest : IntegrationTestBase() {
         assertEquals(HttpStatus.FORBIDDEN_403, invalidCors().getResponse())
     }
 
+    /* Test Redis */
+
+    @Test
+    fun sendMessageToRedis() {
+        val b = getReqBuilder(getPath("/"))
+        assertEquals(HttpStatus.NO_CONTENT_204, getPath("/redis").getResponse())
+    }
+
     /* Test JSON */
     private fun postJson() = getPath("/json").copy(method = HttpMethod.Post)
 

--- a/src/integrationTest/sink2.yaml
+++ b/src/integrationTest/sink2.yaml
@@ -2,7 +2,7 @@
 apiVersion: leia.klira.io/v1
 kind: LeiaSinkProviders
 metadata:
-  name: sink1
+  name: sink2
 spec:
   name: "null"
   type: "null"

--- a/src/main/kotlin/logic/IncomingRequest.kt
+++ b/src/main/kotlin/logic/IncomingRequest.kt
@@ -27,10 +27,10 @@ data class IncomingRequest(
     fun matchCors(origins: List<String>) =
         origin == null || origins.isEmpty() || origins.contains(origin) || origins.contains("*")
 
-    suspend fun readBody(save: Boolean = false): ByteArray {
-        if (save) {
+    suspend fun readBody(): ByteArray {
+        if (savedBody == null) {
             savedBody = readBodyFn()
         }
-        return savedBody ?: readBodyFn()
+        return savedBody!!
     }
 }

--- a/src/main/kotlin/logic/SourceSpecResolver.kt
+++ b/src/main/kotlin/logic/SourceSpecResolver.kt
@@ -73,7 +73,7 @@ class SourceSpecResolver(private val cfg: SourceSpec, private val auth: AuthProv
 
     private fun validateBodyWithJsonSchema(req: IncomingRequest) =
         try {
-            val body = req.readBody().toString(Charsets.UTF_8)
+            val body = runBlocking { req.readBody().toString(Charsets.UTF_8) }
             jsonSchema?.validate(JSONObject(body))
             null
         } catch (e: ValidationException) {

--- a/src/main/kotlin/registry/TomlRegistry.kt
+++ b/src/main/kotlin/registry/TomlRegistry.kt
@@ -61,11 +61,10 @@ class TomlRegistry(configPath: String) : Registry() {
         .build()!!
 
     override fun getMaps(table: Tables): List<Map<String, Any>> =
-        with(computeCurrentState()) {
-            if (this.containsTableArray(table.key)) {
-                this.getTables(table.key).map { it.toMap() }
-            } else emptyList()
-        }
+        holder.getData().values
+            .filter { it.containsTableArray(table.key) }
+            .map { toml -> toml.getTables(table.key).map { it.toMap() } }
+            .flatten()
 
     private fun onUpdate(paths: List<Path>) {
         holder.onChange(paths)
@@ -81,14 +80,6 @@ class TomlRegistry(configPath: String) : Registry() {
             .filter { it.isFile && !it.isHidden && it.extension.toLowerCase() == "toml" }
             .map { it.toPath() }
             .let(this::onUpdate)
-    }
-
-    private fun computeCurrentState(): Toml {
-        val state = Toml()
-        holder.getData().values.forEach {
-            state.read(it)
-        }
-        return state
     }
 
     companion object : KLogging()


### PR DESCRIPTION
This ads simple integration test for Redis. There is also improvement for fetching config from Kubernetes in parallel for different tables.

Also fIxes #92 (reading multiple toml files)