### PR TITLE
Make comparison of headers case insensitive

### DIFF
--- a/src/main/kotlin/auth/BasicAuth.kt
+++ b/src/main/kotlin/auth/BasicAuth.kt
@@ -30,10 +30,10 @@ class BasicAuth(credentials: Map<String, String>) : AuthProvider {
 
 
     override fun verify(matching: List<String>, incomingRequest: IncomingRequest): AuthResult {
-        if (!incomingRequest.headers.containsKey(HEADER))
+        if (!incomingRequest.hasHeader(HEADER))
             return AuthResult.Denied.NoCredentials
 
-        val credential: String = incomingRequest.headers.getValue(HEADER)
+        val credential: String = incomingRequest.getHeaderValue(HEADER)
             .first()
             .removePrefix("Basic")
             .trim()

--- a/src/main/kotlin/auth/jwk/JwkAuth.kt
+++ b/src/main/kotlin/auth/jwk/JwkAuth.kt
@@ -22,7 +22,7 @@ class JwkAuth(
     ) : this(JwtValidator(config))
 
     override fun verify(matching: List<String>, incomingRequest: IncomingRequest): AuthResult {
-        val token: String = incomingRequest.headers["Authorization"]
+        val token: String = incomingRequest.getHeader("Authorization")
             ?.firstOrNull { it.startsWith("Bearer") }
             ?.removePrefix("Bearer")
             ?.trim()

--- a/src/main/kotlin/logic/IncomingRequest.kt
+++ b/src/main/kotlin/logic/IncomingRequest.kt
@@ -13,11 +13,12 @@ data class IncomingRequest(
     val method: HttpMethod,
     private val origin: String?,
     val path: String,
-    val headers: Map<String, List<String>>,
+    private val originalHeaders: Map<String, List<String>>,
     val queryString: String,
     private val host: String?,
     private val readBodyFn: suspend () -> ByteArray
 ) {
+    val headers: Map<String, List<String>> = originalHeaders.mapKeys { it.key.toLowerCase() }
     private var savedBody: ByteArray? = null
     val requestId = generateId().also {
         if (it == 0L) throw IllegalStateException("Generated flake id was 0")
@@ -35,6 +36,11 @@ data class IncomingRequest(
         origin != null && corsHosts.isNotEmpty() && method == HttpMethod.Options
 
     fun matchMethod(methods: Set<HttpMethod>) = methods.let { it.isEmpty() || it.contains(method) }
+
+    fun hasHeader(header: String) = headers.containsKey(header.toLowerCase())
+
+    fun getHeader(header: String) = headers[header.toLowerCase()]
+    fun getHeaderValue(header: String) = headers.getValue(header.toLowerCase())
 
     suspend fun readBody(): ByteArray {
         if (savedBody == null) {

--- a/src/main/kotlin/logic/IncomingRequest.kt
+++ b/src/main/kotlin/logic/IncomingRequest.kt
@@ -13,12 +13,12 @@ data class IncomingRequest(
     val method: HttpMethod,
     private val origin: String?,
     val path: String,
-    private val originalHeaders: Map<String, List<String>>,
+    val headers: Map<String, List<String>>,
     val queryString: String,
     private val host: String?,
     private val readBodyFn: suspend () -> ByteArray
 ) {
-    val headers: Map<String, List<String>> = originalHeaders.mapKeys { it.key.toLowerCase() }
+    private val lowerCaseHeaders: Map<String, List<String>> = headers.mapKeys { it.key.toLowerCase() }
     private var savedBody: ByteArray? = null
     val requestId = generateId().also {
         if (it == 0L) throw IllegalStateException("Generated flake id was 0")
@@ -37,10 +37,10 @@ data class IncomingRequest(
 
     fun matchMethod(methods: Set<HttpMethod>) = methods.let { it.isEmpty() || it.contains(method) }
 
-    fun hasHeader(header: String) = headers.containsKey(header.toLowerCase())
+    fun hasHeader(header: String) = lowerCaseHeaders.containsKey(header.toLowerCase())
 
-    fun getHeader(header: String) = headers[header.toLowerCase()]
-    fun getHeaderValue(header: String) = headers.getValue(header.toLowerCase())
+    fun getHeader(header: String) = lowerCaseHeaders[header.toLowerCase()]
+    fun getHeaderValue(header: String) = lowerCaseHeaders.getValue(header.toLowerCase())
 
     suspend fun readBody(): ByteArray {
         if (savedBody == null) {

--- a/src/test/kotlin/auth/BasicAuthTest.kt
+++ b/src/test/kotlin/auth/BasicAuthTest.kt
@@ -118,7 +118,7 @@ internal fun genericRequest(headers: Map<String, List<String>> = emptyMap()) = I
     method = HttpMethod.Post,
     origin = null,
     path = "/",
-    originalHeaders = headers,
+    headers = headers,
     queryString = "",
     host = null,
     readBodyFn = { ByteArray(0) }

--- a/src/test/kotlin/auth/BasicAuthTest.kt
+++ b/src/test/kotlin/auth/BasicAuthTest.kt
@@ -118,7 +118,7 @@ internal fun genericRequest(headers: Map<String, List<String>> = emptyMap()) = I
     method = HttpMethod.Post,
     origin = null,
     path = "/",
-    headers = headers,
+    originalHeaders = headers,
     queryString = "",
     host = null,
     readBodyFn = { ByteArray(0) }

--- a/src/test/kotlin/auth/JwkAuthTest.kt
+++ b/src/test/kotlin/auth/JwkAuthTest.kt
@@ -46,4 +46,14 @@ class JwkAuthTest {
         result as AuthResult.Authorized
         assertEquals("foo", result.identifier)
     }
+
+    @Test
+    fun `lower case authorization header`() {
+        val auth = JwkAuth(MockJWTDecoder)
+        val requestWithHeaders: IncomingRequest = genericRequest(mapOf("authorization" to listOf("Bearer $EXAMPLE_JWT")))
+        val result: AuthResult = auth.verify(emptyList(), requestWithHeaders)
+        assertTrue(result is AuthResult.Authorized)
+        result as AuthResult.Authorized
+        assertEquals("foo", result.identifier)
+    }
 }


### PR DESCRIPTION
Headers comparison should not be case sensitive now but case sensitivity of headers will be preserved when sending them from leia.

Fixes #98 